### PR TITLE
Increase tolerance to 1000us

### DIFF
--- a/codegen/src/message_ok.rs
+++ b/codegen/src/message_ok.rs
@@ -52,7 +52,7 @@ impl MessageStatusCodegen for Codegen<'_> {
                 // Check that message has been recieved (ever) + that it's on time.
                 const {TIME_TY} current_time = CAN_callback_get_system_time();
                 const uint_fast16_t MS_TO_US = 1000U;
-                const uint_fast16_t LATENESS_TOLERANCE_US = 100U;
+                const uint_fast16_t LATENESS_TOLERANCE_US = 1000U;
 
             {timestamp}
 


### PR DESCRIPTION
Our message ok check is rather primitive and can trip easily, increasing the tolerance to 1000us _isn't_ ideal, but it works for now.